### PR TITLE
Moved player-enemy collision checking to enemy,gd

### DIFF
--- a/Game/Src/Actors/Enemy.gd
+++ b/Game/Src/Actors/Enemy.gd
@@ -1,28 +1,35 @@
-extends ActorBase
+extends ActorBase #Actor.gd
 
-var origin = Vector2()
+#A Vector to store the starting co-ordinates of the enemy.
+onready var origin = Vector2(get_position())
+#Starting direction of the enemy (0 = Still, 1 = Down, 2 = Up, 3 = Right, 4 = Left)
 export(int,"Still","Down","Up","Right","Left") var direction
-export var stray = 60 #how far they will stray from the origin
-
+#How far the enemy will stray from their origin
+export var stray = 60
 
 func _ready():
-	origin.x = position.x
-	origin.y = position.y
-	_get_dir()
+	_get_velocity()
 		
-func _physics_process(delta):
-	_get_dir()
-	move_and_slide(velocity)
+func _physics_process(_delta: float) -> void:
+	_get_velocity()
+	
+	#Code block calls the flip direction function whenever the enemy is 
+	#'stray' pixels from their origin.
 	if origin.y <= position.y-stray:
-		_get_flip()
+		_flip_direction()
 	elif origin.y >= position.y+stray:
-		_get_flip()
+		_flip_direction()
 	if origin.x <= position.x-stray:
-		_get_flip()
+		_flip_direction()
 	elif origin.x >= position.x+stray:
-		_get_flip()
+		_flip_direction()
+	
+	move_and_slide(velocity)
 
-func _get_dir():
+#This function will set the velocity and rotation of the enemy to their appropriate
+#direction.
+func _get_velocity():
+	#1 = Down, 2 = Up, 3 = Right, 4 = Left
 	if direction == 1:
 		$Sprite.rotation_degrees = 90
 		$VisionCone.rotation_degrees = 90
@@ -39,8 +46,9 @@ func _get_dir():
 		$Sprite.rotation_degrees = 180
 		$VisionCone.rotation_degrees = 180
 		velocity.x = -move_speed
-		
-func _get_flip():
+
+func _flip_direction():
+	#1 = Down, 2 = Up, 3 = Right, 4 = Left
 	if direction == 1:
 		direction = 2
 	elif direction == 2:
@@ -52,8 +60,17 @@ func _get_flip():
 	$Sprite.rotation_degrees -= 180
 	$VisionCone.rotation_degrees -= 180
 
+#This function calls the _flip_direction function
+#when the enemy collides with a wall or another enemy.
 func _on_Area2D_body_entered(body):
-	if body.name == "TileMap" or body.get_collision_layer() == 2 or body.get_collision_layer() == 1:
-		_get_flip()
-	#if body.name == "Player":
-	#	get_tree().change_scene("res://Game/Src/Levels/TestLevel.tscn")
+	if body.get_collision_layer() == 2 or body.get_collision_layer() == 4:
+		_flip_direction()
+	#calls the player's lose_game function should they collide.
+	if body.name == "Player":
+		body.lose_game()
+
+
+func _on_VisionCone_body_entered(body):
+	#calls the player's lose_game function should they collide.
+	if body.name == "Player":
+		body.lose_game()

--- a/Game/Src/Actors/Enemy.tscn
+++ b/Game/Src/Actors/Enemy.tscn
@@ -30,10 +30,12 @@ shape = SubResource( 3 )
 [node name="VisionCone" type="Area2D" parent="."]
 
 [node name="VCone" type="Sprite" parent="VisionCone"]
-position = Vector2( 39, 0 )
+show_behind_parent = true
+position = Vector2( 33, 0 )
 texture = ExtResource( 3 )
 
 [node name="CollisionPolygon2D" type="CollisionPolygon2D" parent="VisionCone"]
-polygon = PoolVector2Array( 58, -21, 62, -12, 64, 0, 62, 12, 59, 23, -8, 0 )
+polygon = PoolVector2Array( 52, -20, 55, -13, 57, -1, 56, 14, 53, 23, -7, 0 )
 
 [connection signal="body_entered" from="Area2D" to="." method="_on_Area2D_body_entered"]
+[connection signal="body_entered" from="VisionCone" to="." method="_on_VisionCone_body_entered"]

--- a/Game/Src/Actors/Player.gd
+++ b/Game/Src/Actors/Player.gd
@@ -1,4 +1,4 @@
-extends ActorBase
+extends ActorBase #Actor.gd
 
 func _physics_process(_delta: float) -> void:
 	#keeps the cursor inside the game windoww
@@ -29,9 +29,9 @@ func _get_dir():
 	elif Input.is_action_pressed("move_up") and !Input.is_action_pressed("move_down"):
 		velocity.y = -move_speed
 
+#just resetting the game for now
+func lose_game():
+	get_tree().reload_current_scene()
+
 func _close_game():
 	get_tree().quit()
-
-
-func _on_EnemyDetect_area_entered(area: Area2D) -> void:
-	get_tree().reload_current_scene()

--- a/Game/Src/Actors/Player.tscn
+++ b/Game/Src/Actors/Player.tscn
@@ -1,12 +1,9 @@
-[gd_scene load_steps=5 format=2]
+[gd_scene load_steps=4 format=2]
 
 [ext_resource path="res://Game/Src/Actors/Player.gd" type="Script" id=1]
 [ext_resource path="res://Game/Assets/Temp/manBlue_stand.png" type="Texture" id=2]
 
 [sub_resource type="CircleShape2D" id=1]
-radius = 10.0499
-
-[sub_resource type="CircleShape2D" id=2]
 radius = 10.0499
 
 [node name="Player" type="KinematicBody2D"]
@@ -42,12 +39,3 @@ drag_margin_bottom = 0.1
 __meta__ = {
 "_edit_lock_": true
 }
-
-[node name="EnemyDetect" type="Area2D" parent="."]
-collision_mask = 6
-
-[node name="CollisionShape2D" type="CollisionShape2D" parent="EnemyDetect"]
-modulate = Color( 1, 0.964706, 0.12549, 1 )
-shape = SubResource( 2 )
-
-[connection signal="area_entered" from="EnemyDetect" to="." method="_on_EnemyDetect_area_entered"]

--- a/Game/Src/Levels/TestLevel.tscn
+++ b/Game/Src/Levels/TestLevel.tscn
@@ -41,11 +41,11 @@ move_speed = 120
 [node name="Enemies" type="Node2D" parent="."]
 
 [node name="Enemy1" parent="Enemies" instance=ExtResource( 3 )]
-position = Vector2( 237, 67 )
+position = Vector2( 237, 35 )
 direction = 2
 
 [node name="Enemy2" parent="Enemies" instance=ExtResource( 3 )]
-position = Vector2( 237, 21 )
+position = Vector2( 237, 131 )
 direction = 1
 stray = 100
 


### PR DESCRIPTION
Moved the player-enemy collision checking to the enemy script as the old implementation would reset the level should the player collide with any area2d, also this solution allows us to remove the area2d enemy checker on the player, so a little added efficiency there.