### PR TITLE
Patrolling Bugfix

### DIFF
--- a/Game/Src/Actors/Enemy.gd
+++ b/Game/Src/Actors/Enemy.gd
@@ -11,7 +11,6 @@ func _ready():
 	_get_velocity()
 		
 func _physics_process(_delta: float) -> void:
-	_get_velocity()
 	
 	#Code block calls the flip direction function whenever the enemy is 
 	#'stray' pixels from their origin.
@@ -23,7 +22,7 @@ func _physics_process(_delta: float) -> void:
 		_flip_direction()
 	elif origin.x >= position.x+stray:
 		_flip_direction()
-	
+	_get_velocity()
 	move_and_slide(velocity)
 
 #This function will set the velocity and rotation of the enemy to their appropriate

--- a/Game/Src/Actors/Player.tscn
+++ b/Game/Src/Actors/Player.tscn
@@ -22,12 +22,6 @@ __meta__ = {
 "_editor_description_": ""
 }
 
-[node name="RayCast2D" type="RayCast2D" parent="."]
-cast_to = Vector2( 2000, 0 )
-__meta__ = {
-"_edit_lock_": true
-}
-
 [node name="Camera2D" type="Camera2D" parent="."]
 current = true
 drag_margin_h_enabled = true

--- a/Game/Src/Levels/TestLevel.tscn
+++ b/Game/Src/Levels/TestLevel.tscn
@@ -45,7 +45,7 @@ position = Vector2( 237, 35 )
 direction = 2
 
 [node name="Enemy2" parent="Enemies" instance=ExtResource( 3 )]
-position = Vector2( 237, 131 )
+position = Vector2( 357, 21 )
 direction = 1
 stray = 100
 
@@ -53,7 +53,6 @@ stray = 100
 position = Vector2( 314, 264 )
 move_speed = 50
 direction = 3
-stray = 100
 
 [node name="Enemy4" parent="Enemies" instance=ExtResource( 3 )]
 position = Vector2( 147, 197 )


### PR DESCRIPTION
In the previous branch I was reconstructing some of the code in Player.gd and Enemy.gd to make it more readable, as a result, I made the mistake by putting the _get_velocity() function call above the code block that controls how far the enemies stray from their origin point in the physics_process function; this created an endless loop of flipping directions when the enemy reached their stray limit. 
I have fixed the aforementioned mistake in this commit by placing the  _get_velocity() call to just above the move_and_slide method in the physics_process function.

I also removed the raycast2d from the player as that was from when I was working out a way to have the player's rotation follow the mouse, and the solution I ended on didn't require the raycast2d.